### PR TITLE
Add Font Awesome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
 
   gem 'bootstrap-sass'
+  gem 'font-awesome-sass-rails'
 end
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
       factory_girl (~> 4.1.0)
       railties (>= 3.0.0)
     ffi (1.1.5)
+    font-awesome-sass-rails (2.0.0.0)
+      railties (>= 3.1.1)
+      sass-rails (>= 3.1.1)
     gherkin (2.11.5)
       json (>= 1.4.6)
     haml (3.1.7)
@@ -180,6 +183,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   factory_girl_rails (~> 4.0)
+  font-awesome-sass-rails
   haml-rails
   jquery-rails
   mini_magick

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,6 +15,7 @@
 
 @import "bootstrap";
 @import "bootstrap-responsive";
+@import "font-awesome";
 
 .container {
   padding-top: 2em;


### PR DESCRIPTION
Bootstrap uses [Glyphicons](http://twitter.github.com/bootstrap/base-css.html#icons) by default, mainly becuase they are scalable and stylable, I prefer those from [Font Awesome](https://github.com/littlebtc/font-awesome-sass-rails).

Don't forget to restart your development server after you install it!
